### PR TITLE
Update layout and add tool for user migration

### DIFF
--- a/Library/Preferences/GNUstep.conf
+++ b/Library/Preferences/GNUstep.conf
@@ -30,7 +30,7 @@ GNUSTEP_SYSTEM_APPS=/System/Applications
 # This is where System GUI Applications that only the
 # Administrator can use get installed.
 # Traditionally it is /usr/GNUstep/System/Applications/Admin.
-GNUSTEP_SYSTEM_ADMIN_APPS=/System/Applications
+GNUSTEP_SYSTEM_ADMIN_APPS=/System/Applications/Utilities
 
 # This is where System Web Applications (GSWeb, SOPE) get
 # installed.
@@ -39,48 +39,49 @@ GNUSTEP_SYSTEM_WEB_APPS=/System/WebApps
 
 # This is where System Command-Line Tools get installed.
 # Traditionally it is /usr/GNUstep/System/Tools.
-GNUSTEP_SYSTEM_TOOLS=/System/bin
+GNUSTEP_SYSTEM_TOOLS=/System/Tools
 
 # This is where System Command-Line Tools that only the
 # Administrator can use get installed.  Important: this
 # should not be in the PATH of normal users.
 # Traditionally it is /usr/GNUstep/System/Tools/Admin.
-GNUSTEP_SYSTEM_ADMIN_TOOLS=/System/sbin
+GNUSTEP_SYSTEM_ADMIN_TOOLS=/System/Tools/Admin
 
 # This is where System resources get installed.  This directory will
 # contain a lot of executable code since *step traditionally likes to
 # bundle executables and resources together.
 # Traditionally it is /usr/GNUstep/System/Library.
-GNUSTEP_SYSTEM_LIBRARY=/System
+GNUSTEP_SYSTEM_LIBRARY=/System/Library
 
 # This is where System headers get installed.  They are the
 # library .h headers.
 # Traditionally it is /usr/GNUstep/System/Library/Headers.
-GNUSTEP_SYSTEM_HEADERS=/System/include
+GNUSTEP_SYSTEM_HEADERS=/System/Library/Headers
 
 # This is where System libraries get installed.  By libraries we mean
 # the shared/static object files that you can link into programs.
 # Traditionally it is /usr/GNUstep/System/Library/Libraries.
-GNUSTEP_SYSTEM_LIBRARIES=/System/lib
+GNUSTEP_SYSTEM_LIBRARIES=/System/Library/Libraries
 
 # This is where System documentation get installed.  This is known
 # not to contain any executable, so we keep it separate.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation.
-GNUSTEP_SYSTEM_DOC=/System/Documentation
+GNUSTEP_SYSTEM_DOC=/System/Library/Documentation
 
 # This is where System man pages get installed.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation/man.
-GNUSTEP_SYSTEM_DOC_MAN=/System/share/man
+GNUSTEP_SYSTEM_DOC_MAN=System/Library/Documentation/man
 
 # This is where System info pages get installed.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation/info.
-GNUSTEP_SYSTEM_DOC_INFO=/System/share/info
+GNUSTEP_SYSTEM_DOC_INFO=/System/Library/Documentation/info
 
+# Network Domain
 GNUSTEP_NETWORK_APPS=/Applications
 GNUSTEP_NETWORK_ADMIN_APPS=/Applications/Utilities
 GNUSTEP_NETWORK_WEB_APPS=/Library/WebApplications
-GNUSTEP_NETWORK_TOOLS=/Library/bin
-GNUSTEP_NETWORK_ADMIN_TOOLS=/Library/sbin
+GNUSTEP_NETWORK_TOOLS=/Library/Tools
+GNUSTEP_NETWORK_ADMIN_TOOLS=/Library/Tools/Admin
 GNUSTEP_NETWORK_LIBRARY=/Library
 GNUSTEP_NETWORK_HEADERS=/Library/Headers
 GNUSTEP_NETWORK_LIBRARIES=/Library/Libraries
@@ -88,11 +89,12 @@ GNUSTEP_NETWORK_DOC=/Library/Documentation
 GNUSTEP_NETWORK_DOC_MAN=/Library/Documentation/man
 GNUSTEP_NETWORK_DOC_INFO=/Library/Documentation/info
 
+# Local Domain
 GNUSTEP_LOCAL_APPS=/Applications
 GNUSTEP_LOCAL_ADMIN_APPS=/Applications/Utilities
 GNUSTEP_LOCAL_WEB_APPS=/Library/WebApplications
-GNUSTEP_LOCAL_TOOLS=/Library/bin
-GNUSTEP_LOCAL_ADMIN_TOOLS=/Library/sbin
+GNUSTEP_LOCAL_TOOLS=/Library/Tools
+GNUSTEP_LOCAL_ADMIN_TOOLS=/Library/Tools/Admin
 GNUSTEP_LOCAL_LIBRARY=/Library
 GNUSTEP_LOCAL_HEADERS=/Library/Headers
 GNUSTEP_LOCAL_LIBRARIES=/Library/Libraries
@@ -100,16 +102,12 @@ GNUSTEP_LOCAL_DOC=/Library/Documentation
 GNUSTEP_LOCAL_DOC_MAN=/Library/Documentation/man
 GNUSTEP_LOCAL_DOC_INFO=/Library/Documentation/info
 
-# Important: settings in the User should normally be relative paths,
-# and will be interpreted as relative to the user's directory.  This
-# allows each user to have their own domain to install things.  You
-# can set them to be absolute, mostly if you want to disable them
-# by setting them equal to the ones in the Network domain.
+# User Domain
 GNUSTEP_USER_DIR_APPS=Applications
 GNUSTEP_USER_DIR_ADMIN_APPS=Applications/Utilities
 GNUSTEP_USER_DIR_WEB_APPS=Library/WebApplications
-GNUSTEP_USER_DIR_TOOLS=bin
-GNUSTEP_USER_DIR_ADMIN_TOOLS=sbin
+GNUSTEP_USER_DIR_TOOLS=Tools
+GNUSTEP_USER_DIR_ADMIN_TOOLS=Tools/Admin
 GNUSTEP_USER_DIR_LIBRARY=Library
 GNUSTEP_USER_DIR_HEADERS=Library/Headers
 GNUSTEP_USER_DIR_LIBRARIES=Library/Libraries

--- a/Library/Preferences/GNUstep.conf
+++ b/Library/Preferences/GNUstep.conf
@@ -70,7 +70,7 @@ GNUSTEP_SYSTEM_DOC=/System/Library/Documentation
 
 # This is where System man pages get installed.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation/man.
-GNUSTEP_SYSTEM_DOC_MAN=System/Library/Documentation/man
+GNUSTEP_SYSTEM_DOC_MAN=/System/Library/Documentation/man
 
 # This is where System info pages get installed.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation/info.

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ install: check_root
 	cd $$WORKDIR/workspace && ./configure && gmake && gmake install; \
 	cd $$WORKDIR/apps-systempreferences && gmake -j"${CPUS}" && gmake install; \
 	cd $$WORKDIR/dubstep-dark-theme && gmake -j"${CPUS}" && gmake install; \
+	cd $$WORKDIR/Tools && gmake -j"${CPUS}" && gmake install; \
 	cd $$WORKDIR && tar -cJvf system.txz $(TARGET_DIR); \
 	fi;
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sudo make clean
 
 1. Run tool to migrate users from /home to /Users:
 ```
-/System/Tools/usermigrate <username>
+sudo /System/Tools/usermigrate <username>
 ```
 
 2. After logging out or restarting Launch Workspace:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Since Gershwin leverages GNUstep, it should, in theory, be compatible with any p
 Additionally the following packages must be installed to run Gershwin:
 
 * xorg
+* picom (This is optional but improves theme with rounded corners)
 
 ## Components Included
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,6 @@ cd system && sudo ./tools-scripts/install-dependencies-freebsd
 sudo make install
 ```
 
-4. Migrate Users:
-```
-sudo /System/Tools/migrateuser username
-```
-
 ## Uninstallation
 
 ```

--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ sudo make clean
 
 ## Usage
 
-1. Source GNUstep.sh:
+1. Run tool to migrate users from /home to /Users:
 ```
-. /System/Makefiles/GNUstep.sh 
+. /System/Tools/usermigrate <username>
 ```
 
-2. Launch Workspace:
+2. After logging out or restarting Launch Workspace:
 ```
 startx /System/Library/Scripts/Gershwin-X11
 ```

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ These components are installed to the following directories within the SYSTEM do
 - **Applications**: `/System/Applications`
 - **Admin Applications**: `/System/Applications`
 - **Web Applications**: `/System/WebApps`
-- **Tools**: `/System/bin`
-- **Admin Tools**: `/System/sbin`
-- **Library**: `/System/lib`
-- **Headers**: `/System/include`
-- **Libraries**: `/System/lib`
-- **Documentation**: `/System/Documentation`
-- **Man Pages**: `/System/share/man`
-- **Info Pages**: `/System/share/info`
+- **Tools**: `/System/Tools`
+- **Admin Tools**: `/System/Tools/Admin`
+- **Library**: `/System/Library`
+- **Headers**: `/System/Library/Headers`
+- **Libraries**: `/System/Library/Libraries`
+- **Documentation**: `/System/Library/Documentation`
+- **Man Pages**: `/System/Library/Documentation/man`
+- **Info Pages**: `//System/Library/Documentation/info`
 
 ## Installation for Debian
 
@@ -81,6 +81,11 @@ cd system && sudo ./tools-scripts/install-dependencies-freebsd
 3. Install using make:
 ```
 sudo make install
+```
+
+4. Migrate Users:
+```
+sudo /System/Tools/migrateuser username
 ```
 
 ## Uninstallation

--- a/README.md
+++ b/README.md
@@ -33,16 +33,17 @@ Additionally the following packages must be installed to run Gershwin:
 These components are installed to the following directories within the SYSTEM domain:
 
 - **Applications**: `/System/Applications`
-- **Admin Applications**: `/System/Applications`
+- **Admin Applications**: `/System/Applications/Utilities`
 - **Web Applications**: `/System/WebApps`
 - **Tools**: `/System/Tools`
 - **Admin Tools**: `/System/Tools/Admin`
 - **Library**: `/System/Library`
+- **Fonts**: `/System/Library/Fonts`
 - **Headers**: `/System/Library/Headers`
 - **Libraries**: `/System/Library/Libraries`
 - **Documentation**: `/System/Library/Documentation`
-- **Man Pages**: `/System/Library/Documentation/man`
 - **Info Pages**: `//System/Library/Documentation/info`
+- **Man Pages**: `/System/Library/Documentation/man`
 
 ## Installation for Debian
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ sudo make clean
 
 1. Run tool to migrate users from /home to /Users:
 ```
-. /System/Tools/usermigrate <username>
+/System/Tools/usermigrate <username>
 ```
 
 2. After logging out or restarting Launch Workspace:

--- a/Tools/GNUmakefile
+++ b/Tools/GNUmakefile
@@ -24,7 +24,7 @@ TOOL_INSTALL_DIR = $(INSTALL_DIR)
 all: $(TOOL_NAME)
 
 $(TOOL_NAME): $(TOOL_SRC)
-	clang -o $(TOOL_NAME) $(TOOL_SRC) `gnustep-config --objc-flags` `gnustep-config --base-libs`
+	clang -o $(TOOL_NAME) $(TOOL_SRC) `gnustep-config --objc-flags` `gnustep-config --base-libs` -Wl,-rpath,/System/Library/Libraries/
 
 # Install target
 install: $(TOOL_NAME)

--- a/Tools/GNUmakefile
+++ b/Tools/GNUmakefile
@@ -1,0 +1,41 @@
+# GNUMakefile for usermigrate
+
+# Define the tool name and source files
+TOOL_NAME = usermigrate
+TOOL_SRC = usermigrate.m
+
+# GNUstep configuration for compiling Objective-C
+GNUSTEP_INSTALLATION_DOMAIN = SYSTEM
+GNUSTEP_MAKEFILES = /System/Makefiles
+
+include $(GNUSTEP_MAKEFILES)/common.make
+
+# Objective-C flags and libraries
+ADDITIONAL_OBJCFLAGS = -Wall
+ADDITIONAL_LDFLAGS = -L$(GNUSTEP_INSTALLATION_DIR)/Library/Libraries -lgnustep-base
+
+# Installation directories
+INSTALL_DIR = /System/Tools
+
+# Installation directory for the tool
+TOOL_INSTALL_DIR = $(INSTALL_DIR)
+
+# Default target to build the tool
+all: $(TOOL_NAME)
+
+$(TOOL_NAME): $(TOOL_SRC)
+	clang -o $(TOOL_NAME) $(TOOL_SRC) `gnustep-config --objc-flags` `gnustep-config --base-libs`
+
+# Install target
+install: $(TOOL_NAME)
+	@echo "Installing $(TOOL_NAME) to $(INSTALL_DIR)"
+	install -d $(INSTALL_DIR)
+	install -m 755 $(TOOL_NAME) $(TOOL_INSTALL_DIR)
+
+# Clean target to remove build artifacts
+clean:
+	@echo "Cleaning up..."
+	rm -f $(TOOL_NAME)
+	rm -f $(TOOL_NAME) $(TOOL_NAME).d
+
+.PHONY: all install clean

--- a/Tools/usermigrate.m
+++ b/Tools/usermigrate.m
@@ -2,6 +2,12 @@
 
 // Function to run pwd_mkdb with hardcoded path and arguments
 BOOL runPwdMkdb() {
+    // Change the working directory to root to avoid issues with the current directory
+    if (![[NSFileManager defaultManager] changeCurrentDirectoryPath:@"/"]) {
+        NSLog(@"Failed to change directory to /");
+        return NO;
+    }
+
     // Hardcoded path and arguments for pwd_mkdb
     NSString *pwdMkdbPath = @"/usr/sbin/pwd_mkdb";
     NSArray *arguments = @[@"-p", @"/etc/master.passwd"];

--- a/Tools/usermigrate.m
+++ b/Tools/usermigrate.m
@@ -4,7 +4,7 @@ void migrateUser(NSString *username) {
     NSString *homeDir = [NSString stringWithFormat:@"/home/%@", username];
     NSString *usersDir = @"/Users";
     NSString *newHomeDir = [NSString stringWithFormat:@"%@/%@", usersDir, username];
-
+    
     NSFileManager *fileManager = [NSFileManager defaultManager];
 
     // Create /Users directory if it doesn't exist
@@ -19,26 +19,102 @@ void migrateUser(NSString *username) {
         }
     }
 
-    // Check if the user's home directory exists
-    if (![fileManager fileExistsAtPath:homeDir]) {
-        NSLog(@"User's home directory does not exist in /home.");
+    // Check if the user's home directory has already been moved
+    if ([fileManager fileExistsAtPath:newHomeDir]) {
+        NSLog(@"User's home directory is already at the new location: %@", newHomeDir);
+        // Proceed to update /etc/passwd or /etc/master.passwd directly
+    } else {
+        // Check if the user's home directory exists in the old location
+        if (![fileManager fileExistsAtPath:homeDir]) {
+            NSLog(@"User's home directory does not exist in /home.");
+            return;
+        }
+
+        // Copy the user's home directory
+        NSError *copyError = nil;
+        if ([fileManager copyItemAtPath:homeDir toPath:newHomeDir error:&copyError]) {
+            NSLog(@"Successfully copied %@ to %@", homeDir, newHomeDir);
+            
+            // Delete all files in the old home directory without removing the dataset
+            NSError *contentsError = nil;
+            NSArray *contents = [fileManager contentsOfDirectoryAtPath:homeDir error:&contentsError];
+            
+            if (contentsError) {
+                NSLog(@"Error reading contents of old home directory: %@", [contentsError localizedDescription]);
+            } else {
+                for (NSString *file in contents) {
+                    NSError *deleteError = nil;
+                    NSString *filePath = [homeDir stringByAppendingPathComponent:file];
+                    if (![fileManager removeItemAtPath:filePath error:&deleteError]) {
+                        NSLog(@"Error deleting file %@: %@", filePath, [deleteError localizedDescription]);
+                    } else {
+                        NSLog(@"Deleted file: %@", filePath);
+                    }
+                }
+            }
+        } else {
+            NSLog(@"Error copying home directory: %@", [copyError localizedDescription]);
+            return;
+        }
+    }
+
+    // Detect whether /etc/master.passwd exists
+    NSString *masterPasswdPath = @"/etc/master.passwd";
+    NSString *passwdPath;
+    BOOL isMasterPasswd = NO;
+
+    if ([fileManager fileExistsAtPath:masterPasswdPath]) {
+        passwdPath = masterPasswdPath;
+        isMasterPasswd = YES;
+        NSLog(@"Detected FreeBSD system with /etc/master.passwd.");
+    } else {
+        passwdPath = @"/etc/passwd";
+    }
+
+    // Update the appropriate password file
+    NSError *readError = nil;
+    NSString *passwdContents = [NSString stringWithContentsOfFile:passwdPath encoding:NSUTF8StringEncoding error:&readError];
+
+    if (readError) {
+        NSLog(@"Error reading %@: %@", passwdPath, [readError localizedDescription]);
         return;
     }
 
-    // Move the user's home directory
-    NSError *moveError = nil;
-    if ([fileManager moveItemAtPath:homeDir toPath:newHomeDir error:&moveError]) {
-        NSLog(@"Successfully moved %@ to %@", homeDir, newHomeDir);
-        
-        // Update /etc/passwd
-        NSString *passwdPath = @"/etc/passwd";
-        NSString *passwdContents = [NSString stringWithContentsOfFile:passwdPath encoding:NSUTF8StringEncoding error:nil];
-        NSString *updatedPasswdContents = [passwdContents stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%@:", homeDir]
-                                                                                    withString:[NSString stringWithFormat:@"%@:", newHomeDir]];
-        [updatedPasswdContents writeToFile:passwdPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
-        NSLog(@"Updated /etc/passwd to reflect new home directory.");
+    // Create the exact strings to replace and their replacements
+    NSString *oldHomeDirString = [NSString stringWithFormat:@":%@:", homeDir]; // Including ':' to ensure the exact match
+    NSString *newHomeDirString = [NSString stringWithFormat:@":%@:", newHomeDir];
+
+    // Check if oldHomeDirString exists in passwdContents before replacing
+    if ([passwdContents containsString:oldHomeDirString]) {
+        NSString *updatedPasswdContents = [passwdContents stringByReplacingOccurrencesOfString:oldHomeDirString
+                                                                                    withString:newHomeDirString];
+
+        NSError *writeError = nil;
+        [updatedPasswdContents writeToFile:passwdPath atomically:YES encoding:NSUTF8StringEncoding error:&writeError];
+
+        if (writeError) {
+            NSLog(@"Error updating %@: %@", passwdPath, [writeError localizedDescription]);
+        } else {
+            NSLog(@"Updated %@ to reflect new home directory.", passwdPath);
+
+            // If using master.passwd, run pwd_mkdb to rebuild the user database
+            if (isMasterPasswd) {
+                NSTask *pwdMkdbTask = [[NSTask alloc] init];
+                [pwdMkdbTask setLaunchPath:@"/usr/sbin/pwd_mkdb"];
+                [pwdMkdbTask setArguments:@[@"-p", masterPasswdPath]];
+                
+                [pwdMkdbTask launch];
+                [pwdMkdbTask waitUntilExit];
+                
+                if ([pwdMkdbTask terminationStatus] == 0) {
+                    NSLog(@"Successfully rebuilt the user database using pwd_mkdb.");
+                } else {
+                    NSLog(@"Failed to rebuild the user database using pwd_mkdb.");
+                }
+            }
+        }
     } else {
-        NSLog(@"Error moving home directory: %@", [moveError localizedDescription]);
+        NSLog(@"Home directory entry not found in %@ or already updated.", passwdPath);
     }
 }
 

--- a/Tools/usermigrate.m
+++ b/Tools/usermigrate.m
@@ -1,0 +1,56 @@
+#import <Foundation/Foundation.h>
+
+void migrateUser(NSString *username) {
+    NSString *homeDir = [NSString stringWithFormat:@"/home/%@", username];
+    NSString *usersDir = @"/Users";
+    NSString *newHomeDir = [NSString stringWithFormat:@"%@/%@", usersDir, username];
+
+    NSFileManager *fileManager = [NSFileManager defaultManager];
+
+    // Create /Users directory if it doesn't exist
+    if (![fileManager fileExistsAtPath:usersDir]) {
+        NSError *error = nil;
+        [fileManager createDirectoryAtPath:usersDir withIntermediateDirectories:YES attributes:nil error:&error];
+        if (error) {
+            NSLog(@"Error creating /Users directory: %@", [error localizedDescription]);
+            return;
+        } else {
+            NSLog(@"Created /Users directory.");
+        }
+    }
+
+    // Check if the user's home directory exists
+    if (![fileManager fileExistsAtPath:homeDir]) {
+        NSLog(@"User's home directory does not exist in /home.");
+        return;
+    }
+
+    // Move the user's home directory
+    NSError *moveError = nil;
+    if ([fileManager moveItemAtPath:homeDir toPath:newHomeDir error:&moveError]) {
+        NSLog(@"Successfully moved %@ to %@", homeDir, newHomeDir);
+        
+        // Update /etc/passwd
+        NSString *passwdPath = @"/etc/passwd";
+        NSString *passwdContents = [NSString stringWithContentsOfFile:passwdPath encoding:NSUTF8StringEncoding error:nil];
+        NSString *updatedPasswdContents = [passwdContents stringByReplacingOccurrencesOfString:[NSString stringWithFormat:@"%@:", homeDir]
+                                                                                    withString:[NSString stringWithFormat:@"%@:", newHomeDir]];
+        [updatedPasswdContents writeToFile:passwdPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
+        NSLog(@"Updated /etc/passwd to reflect new home directory.");
+    } else {
+        NSLog(@"Error moving home directory: %@", [moveError localizedDescription]);
+    }
+}
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        if (argc != 2) {
+            NSLog(@"Usage: usermigrate <username>");
+            return 1;
+        }
+        
+        NSString *username = [NSString stringWithUTF8String:argv[1]];
+        migrateUser(username);
+    }
+    return 0;
+}


### PR DESCRIPTION
* This tool will aid in migrating users from /home to /Users on a Linux or BSD system.
* It has been tested on both prior to the PR.
* README has been updated with usage changes, and very minor layout updates.