### PR TITLE
Layout update to standardize more with GNUstep and Mac

### DIFF
--- a/Library/Preferences/GNUstep.conf
+++ b/Library/Preferences/GNUstep.conf
@@ -30,7 +30,7 @@ GNUSTEP_SYSTEM_APPS=/System/Applications
 # This is where System GUI Applications that only the
 # Administrator can use get installed.
 # Traditionally it is /usr/GNUstep/System/Applications/Admin.
-GNUSTEP_SYSTEM_ADMIN_APPS=/System/Applications
+GNUSTEP_SYSTEM_ADMIN_APPS=/System/Applications/Utilities
 
 # This is where System Web Applications (GSWeb, SOPE) get
 # installed.
@@ -39,48 +39,49 @@ GNUSTEP_SYSTEM_WEB_APPS=/System/WebApps
 
 # This is where System Command-Line Tools get installed.
 # Traditionally it is /usr/GNUstep/System/Tools.
-GNUSTEP_SYSTEM_TOOLS=/System/bin
+GNUSTEP_SYSTEM_TOOLS=/System/Tools
 
 # This is where System Command-Line Tools that only the
 # Administrator can use get installed.  Important: this
 # should not be in the PATH of normal users.
 # Traditionally it is /usr/GNUstep/System/Tools/Admin.
-GNUSTEP_SYSTEM_ADMIN_TOOLS=/System/sbin
+GNUSTEP_SYSTEM_ADMIN_TOOLS=/System/Tools/Admin
 
 # This is where System resources get installed.  This directory will
 # contain a lot of executable code since *step traditionally likes to
 # bundle executables and resources together.
 # Traditionally it is /usr/GNUstep/System/Library.
-GNUSTEP_SYSTEM_LIBRARY=/System
+GNUSTEP_SYSTEM_LIBRARY=/System/Library
 
 # This is where System headers get installed.  They are the
 # library .h headers.
 # Traditionally it is /usr/GNUstep/System/Library/Headers.
-GNUSTEP_SYSTEM_HEADERS=/System/include
+GNUSTEP_SYSTEM_HEADERS=/System/Library/Headers
 
 # This is where System libraries get installed.  By libraries we mean
 # the shared/static object files that you can link into programs.
 # Traditionally it is /usr/GNUstep/System/Library/Libraries.
-GNUSTEP_SYSTEM_LIBRARIES=/System/lib
+GNUSTEP_SYSTEM_LIBRARIES=/System/Library/Libraries
 
 # This is where System documentation get installed.  This is known
 # not to contain any executable, so we keep it separate.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation.
-GNUSTEP_SYSTEM_DOC=/System/Documentation
+GNUSTEP_SYSTEM_DOC=/System/Library/Documentation
 
 # This is where System man pages get installed.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation/man.
-GNUSTEP_SYSTEM_DOC_MAN=/System/share/man
+GNUSTEP_SYSTEM_DOC_MAN=/System/Library/Documentation/man
 
 # This is where System info pages get installed.
 # Traditionally it is /usr/GNUstep/System/Library/Documentation/info.
-GNUSTEP_SYSTEM_DOC_INFO=/System/share/info
+GNUSTEP_SYSTEM_DOC_INFO=/System/Library/Documentation/info
 
+# Network Domain
 GNUSTEP_NETWORK_APPS=/Applications
 GNUSTEP_NETWORK_ADMIN_APPS=/Applications/Utilities
 GNUSTEP_NETWORK_WEB_APPS=/Library/WebApplications
-GNUSTEP_NETWORK_TOOLS=/Library/bin
-GNUSTEP_NETWORK_ADMIN_TOOLS=/Library/sbin
+GNUSTEP_NETWORK_TOOLS=/Library/Tools
+GNUSTEP_NETWORK_ADMIN_TOOLS=/Library/Tools/Admin
 GNUSTEP_NETWORK_LIBRARY=/Library
 GNUSTEP_NETWORK_HEADERS=/Library/Headers
 GNUSTEP_NETWORK_LIBRARIES=/Library/Libraries
@@ -88,11 +89,12 @@ GNUSTEP_NETWORK_DOC=/Library/Documentation
 GNUSTEP_NETWORK_DOC_MAN=/Library/Documentation/man
 GNUSTEP_NETWORK_DOC_INFO=/Library/Documentation/info
 
+# Local Domain
 GNUSTEP_LOCAL_APPS=/Applications
 GNUSTEP_LOCAL_ADMIN_APPS=/Applications/Utilities
 GNUSTEP_LOCAL_WEB_APPS=/Library/WebApplications
-GNUSTEP_LOCAL_TOOLS=/Library/bin
-GNUSTEP_LOCAL_ADMIN_TOOLS=/Library/sbin
+GNUSTEP_LOCAL_TOOLS=/Library/Tools
+GNUSTEP_LOCAL_ADMIN_TOOLS=/Library/Tools/Admin
 GNUSTEP_LOCAL_LIBRARY=/Library
 GNUSTEP_LOCAL_HEADERS=/Library/Headers
 GNUSTEP_LOCAL_LIBRARIES=/Library/Libraries
@@ -100,16 +102,12 @@ GNUSTEP_LOCAL_DOC=/Library/Documentation
 GNUSTEP_LOCAL_DOC_MAN=/Library/Documentation/man
 GNUSTEP_LOCAL_DOC_INFO=/Library/Documentation/info
 
-# Important: settings in the User should normally be relative paths,
-# and will be interpreted as relative to the user's directory.  This
-# allows each user to have their own domain to install things.  You
-# can set them to be absolute, mostly if you want to disable them
-# by setting them equal to the ones in the Network domain.
+# User Domain
 GNUSTEP_USER_DIR_APPS=Applications
 GNUSTEP_USER_DIR_ADMIN_APPS=Applications/Utilities
 GNUSTEP_USER_DIR_WEB_APPS=Library/WebApplications
-GNUSTEP_USER_DIR_TOOLS=bin
-GNUSTEP_USER_DIR_ADMIN_TOOLS=sbin
+GNUSTEP_USER_DIR_TOOLS=Tools
+GNUSTEP_USER_DIR_ADMIN_TOOLS=Tools/Admin
 GNUSTEP_USER_DIR_LIBRARY=Library
 GNUSTEP_USER_DIR_HEADERS=Library/Headers
 GNUSTEP_USER_DIR_LIBRARIES=Library/Libraries

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ These components are installed to the following directories within the SYSTEM do
 - **Applications**: `/System/Applications`
 - **Admin Applications**: `/System/Applications`
 - **Web Applications**: `/System/WebApps`
-- **Tools**: `/System/bin`
-- **Admin Tools**: `/System/sbin`
-- **Library**: `/System/lib`
-- **Headers**: `/System/include`
-- **Libraries**: `/System/lib`
+- **Tools**: `/System/Tools`
+- **Admin Tools**: `/System/Tools/Admin`
+- **Library**: `/System/Library`
+- **Headers**: `/System/Library/Headers`
+- **Libraries**: `/System/Library/Libraries`
 - **Documentation**: `/System/Documentation`
-- **Man Pages**: `/System/share/man`
-- **Info Pages**: `/System/share/info`
+- **Man Pages**: `/System/Library/Documentation/man`
+- **Info Pages**: `/System/Library/Documentation/info`
 
 ## Installation for Debian
 


### PR DESCRIPTION
This updates the layout with a few notable changes so that it better standardizes with how the GNUstep layout, or an OS X install, or macOS install would typically handle things.  

* Installs Admin Apps to Applications/Utilities
* Replace bin with Tools
* Replace sbin with Tools/Admin
* Replace include with Library/Headers
* Replace lib with Library/Libraries
* Replace Documentation with Library/Documentation
* Replace documentation dirs under share with new dirs under Library/Documentation